### PR TITLE
embed the ApiRoot into the PathTo instances in macros

### DIFF
--- a/akka-client/src/main/scala/com/qvantel/jsonapi/client/akka/AkkaClient.scala
+++ b/akka-client/src/main/scala/com/qvantel/jsonapi/client/akka/AkkaClient.scala
@@ -22,7 +22,7 @@ object AkkaClient {
 
   implicit def instance[A](implicit rt: ResourceType[A],
                            reader: JsonApiReader[A],
-                           identifiable: Identifiable[A],
+                           pathTo: PathTo[A],
                            m: ActorMaterializer,
                            system: ActorSystem,
                            endpoint: ApiEndpoint): JsonApiClient[A] = {
@@ -60,7 +60,7 @@ object AkkaClient {
 
       override def one(id: String, include: Set[String] = Set.empty): IO[Option[A]] =
         endpoint.uri.flatMap { baseUri =>
-          val reqUri = baseUri / rt.resourceType / id
+          val reqUri = baseUri / pathTo.self(id)
 
           mkRequest(addInclude(reqUri, include).toString).flatMap(respToEntity(_, include))
         }
@@ -93,7 +93,7 @@ object AkkaClient {
 
       override def filter(filter: String, include: Set[String]) =
         endpoint.uri.flatMap { baseUri =>
-          val reqUri = baseUri / rt.resourceType ? ("filter" -> filter)
+          val reqUri = baseUri / pathTo.root ? ("filter" -> filter)
 
           mkRequest(addInclude(reqUri, include).toString).flatMap(respoToEntities(_, include))
         }

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ val scala211 = Seq(
 
 description in ThisBuild := "jsonapi.org scala implementation"
 
-version in ThisBuild := "6.1.1"
+version in ThisBuild := "7.0.0"
 
 startYear in ThisBuild := Some(2015)
 

--- a/core/src/main/scala/com/qvantel/jsonapi/JsonApiResourceMacro.scala
+++ b/core/src/main/scala/com/qvantel/jsonapi/JsonApiResourceMacro.scala
@@ -47,7 +47,12 @@ final class JsonApiResourceMacro(val c: WhiteboxContext) extends JsonApiCommon {
     val path = s"/$resourceTypeName"
     q"""implicit final val ${TermName(s"${name}PathTo")}: _root_.com.qvantel.jsonapi.PathTo[$name] = new _root_.com.qvantel.jsonapi.PathTo[$name] {
           import _root_.com.netaporter.uri.dsl._
-          override final def self(id: String): _root_.com.netaporter.uri.Uri = $path / id
+
+          override final val root: _root_.com.netaporter.uri.Uri =
+            implicitly[_root_.com.qvantel.jsonapi.ApiRoot].apiRoot match {
+              case Some(root) => root / $resourceTypeName
+              case None => $path
+            }
         }"""
   }
 

--- a/core/src/main/scala/com/qvantel/jsonapi/Link.scala
+++ b/core/src/main/scala/com/qvantel/jsonapi/Link.scala
@@ -33,19 +33,13 @@ import _root_.spray.json.DefaultJsonProtocol._
 import _root_.spray.json._
 
 object Link {
-  private[this] def links[P](parent: P, name: String)(implicit pathToParent: PathTo[P], apiRoot: ApiRoot): JsObject =
-    apiRoot match {
-      case ApiRoot(Some(root)) =>
-        JsObject("related" -> implicitly[JsonWriter[Uri]].write(root / pathToParent.entity(parent) / name))
-      case ApiRoot(None) =>
-        JsObject("related" -> implicitly[JsonWriter[Uri]].write(pathToParent.entity(parent) / name))
-    }
+  private[this] def links[P](parent: P, name: String)(implicit pathToParent: PathTo[P]): JsObject =
+    JsObject("related" -> implicitly[JsonWriter[Uri]].write(pathToParent.entity(parent) / name))
 
   def to[A, P](parent: P, relation: ToOne[A], name: String)(implicit identifiable: Identifiable[A],
                                                             rt: ResourceType[A],
                                                             pathTo: PathTo[A],
-                                                            pathToParent: PathTo[P],
-                                                            apiRoot: ApiRoot): JsValue = {
+                                                            pathToParent: PathTo[P]): JsValue = {
     def resourceLinkage(id: String): JsObject =
       JsObject("type" -> implicitly[ResourceType[A]].resourceType.toJson, "id" -> id.toJson)
 
@@ -61,8 +55,7 @@ object Link {
   def to[A, P](parent: P, maybeRelation: Option[ToOne[A]], name: String)(implicit identifiable: Identifiable[A],
                                                                          rt: ResourceType[A],
                                                                          pathTo: PathTo[A],
-                                                                         pathToParent: PathTo[P],
-                                                                         apiRoot: ApiRoot): JsValue = {
+                                                                         pathToParent: PathTo[P]): JsValue = {
     def resourceLinkage(id: String): JsObject =
       JsObject("type" -> implicitly[ResourceType[A]].resourceType.toJson, "id" -> id.toJson)
 
@@ -81,8 +74,7 @@ object Link {
   def to[A, P](parent: P, maybeRelation: JsonOption[ToOne[A]], name: String)(implicit identifiable: Identifiable[A],
                                                                              rt: ResourceType[A],
                                                                              pathTo: PathTo[A],
-                                                                             pathToParent: PathTo[P],
-                                                                             apiRoot: ApiRoot): JsValue = {
+                                                                             pathToParent: PathTo[P]): JsValue = {
     def resourceLinkage(id: String): JsObject =
       JsObject("type" -> implicitly[ResourceType[A]].resourceType.toJson, "id" -> id.toJson)
 
@@ -104,8 +96,7 @@ object Link {
   def to[A, P](parent: P, relation: ToMany[A], name: String)(implicit identifiable: Identifiable[A],
                                                              rt: ResourceType[A],
                                                              pathTo: PathTo[A],
-                                                             pathToParent: PathTo[P],
-                                                             apiRoot: ApiRoot): JsValue =
+                                                             pathToParent: PathTo[P]): JsValue =
     relation match {
       case ToMany.IdsReference(ids) =>
         val linksTuple: (String, JsValue) = "links" -> links(parent, name)
@@ -130,8 +121,7 @@ object Link {
     }
 
   def to[A <: Coproduct, P](parent: P, relation: PolyToOne[A], name: String)(implicit identifiable: PolyIdentifiable[A],
-                                                                             pathToParent: PathTo[P],
-                                                                             apiRoot: ApiRoot): JsValue = {
+                                                                             pathToParent: PathTo[P]): JsValue = {
     def resourceLinkage(tpe: String, id: String): JsObject =
       JsObject("type" -> tpe.toJson, "id" -> id.toJson)
 
@@ -146,8 +136,7 @@ object Link {
 
   def to[A <: Coproduct, P](parent: P, maybeRelation: Option[PolyToOne[A]], name: String)(
       implicit identifiable: PolyIdentifiable[A],
-      pathToParent: PathTo[P],
-      apiRoot: ApiRoot): JsValue = {
+      pathToParent: PathTo[P]): JsValue = {
     def resourceLinkage(tpe: String, id: String): JsObject =
       JsObject("type" -> tpe.toJson, "id" -> id.toJson)
 
@@ -165,8 +154,7 @@ object Link {
 
   def to[A <: Coproduct, P](parent: P, maybeRelation: JsonOption[PolyToOne[A]], name: String)(
       implicit identifiable: PolyIdentifiable[A],
-      pathToParent: PathTo[P],
-      apiRoot: ApiRoot): JsValue = {
+      pathToParent: PathTo[P]): JsValue = {
     def resourceLinkage(tpe: String, id: String): JsObject =
       JsObject("type" -> tpe.toJson, "id" -> id.toJson)
 
@@ -187,8 +175,7 @@ object Link {
 
   def to[A <: Coproduct, P](parent: P, relation: PolyToMany[A], name: String)(
       implicit identifiable: PolyIdentifiable[A],
-      pathToParent: PathTo[P],
-      apiRoot: ApiRoot): JsValue =
+      pathToParent: PathTo[P]): JsValue =
     relation match {
       case PolyToMany.IdsReference(rels) =>
         val linksTuple: (String, JsValue) = "links" -> links(parent, name)
@@ -261,8 +248,7 @@ object Link {
 
   def toNoParentPath[A, P](parent: P, relation: ToMany[A], name: String)(implicit identifiable: Identifiable[A],
                                                                          rt: ResourceType[A],
-                                                                         pathTo: PathTo[A],
-                                                                         apiRoot: ApiRoot): JsValue =
+                                                                         pathTo: PathTo[A]): JsValue =
     relation match {
       case ToMany.IdsReference(ids) =>
         val resourceLinkage = ids.map { id =>

--- a/core/src/main/scala/com/qvantel/jsonapi/PathTo.scala
+++ b/core/src/main/scala/com/qvantel/jsonapi/PathTo.scala
@@ -27,10 +27,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.qvantel.jsonapi
 
 import com.netaporter.uri.Uri
+import com.netaporter.uri.dsl._
 
 abstract class PathTo[A: Identifiable] {
-  def self(id: String): Uri
-  def entity(a: A): Uri = self(implicitly[Identifiable[A]].identify(a))
+  def self(id: String): Uri = root / id
+  def entity(a: A): Uri     = self(implicitly[Identifiable[A]].identify(a))
+  def root: Uri
 }
 
-object PathTo {}
+object PathTo {
+  def apply[A](implicit pt: PathTo[A]) = implicitly[PathTo[A]]
+}

--- a/core/src/main/scala/com/qvantel/jsonapi/macrosupport/JsonApiWriters.scala
+++ b/core/src/main/scala/com/qvantel/jsonapi/macrosupport/JsonApiWriters.scala
@@ -39,15 +39,8 @@ trait JsonApiWriters extends JsonApiCommon {
     q"_root_.spray.json.JsString(implicitly[_root_.com.qvantel.jsonapi.Identifiable[$t]].identify($objName))"
 
   private[this] def selfPathJson(t: c.Type, objName: TermName): c.Tree = {
-    val root = TermName(c.freshName())
-
     q"""
-       implicitly[_root_.com.qvantel.jsonapi.ApiRoot].apiRoot match {
-         case Some($root) =>
-           import _root_.com.netaporter.uri.dsl._
-           implicitly[_root_.spray.json.JsonWriter[_root_.com.netaporter.uri.Uri]].write($root / implicitly[_root_.com.qvantel.jsonapi.PathTo[$t]].entity($objName))
-         case None => implicitly[_root_.spray.json.JsonWriter[_root_.com.netaporter.uri.Uri]].write(implicitly[_root_.com.qvantel.jsonapi.PathTo[$t]].entity($objName))
-       }
+       implicitly[_root_.spray.json.JsonWriter[_root_.com.netaporter.uri.Uri]].write(implicitly[_root_.com.qvantel.jsonapi.PathTo[$t]].entity($objName))
       """
   }
 

--- a/core/src/test/scala/com/qvantel/jsonapi/CoproductSpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/CoproductSpec.scala
@@ -64,7 +64,7 @@ final class CoproductSpec extends Specification {
     implicit val limbResourceType: ResourceType[Limb] = ResourceType[Limb]("limbs")
     implicit val limbIdentifiable: Identifiable[Limb] = Identifiable.by(_.id)
     implicit val limbPathTo: PathTo[Limb] = new PathTo[Limb] {
-      override final def self(id: String): Uri = "/limbs" / id
+      override def root: Uri = "/limbs"
     }
     implicit val limbJsonApiFormat: JsonApiFormat[Limb] = jsonApiFormat[Limb]
 
@@ -75,7 +75,7 @@ final class CoproductSpec extends Specification {
     implicit val eyeResourceType: ResourceType[Eye] = ResourceType[Eye]("eyes")
     implicit val eyeIdentifiable: Identifiable[Eye] = Identifiable.by(_.id)
     implicit val eyePathTo: PathTo[Eye] = new PathTo[Eye] {
-      override final def self(id: String): Uri = "/eyes" / id
+      override def root: Uri = "/eyes"
     }
     implicit val eyeJsonApiFormat: JsonApiFormat[Eye] = jsonApiFormat[Eye]
 
@@ -86,7 +86,7 @@ final class CoproductSpec extends Specification {
     implicit val lightBulbResourceType: ResourceType[LightBulb] = ResourceType[LightBulb]("light-bulbs")
     implicit val lightBulbIdentifiable: Identifiable[LightBulb] = Identifiable.by(_.id)
     implicit val lightBulbPathTo: PathTo[LightBulb] = new PathTo[LightBulb] {
-      override final def self(id: String): Uri = "/light-bulbs" / id
+      override def root: Uri = "/light-bulbs"
     }
     implicit val lightBulbJsonApiFormat: JsonApiFormat[LightBulb] = jsonApiFormat[LightBulb]
 
@@ -97,7 +97,7 @@ final class CoproductSpec extends Specification {
     implicit val robotResourceType: ResourceType[Robot] = ResourceType[Robot]("robots")
     implicit val robotIdentifiable: Identifiable[Robot] = Identifiable.by(_.id)
     implicit val robotPathTo: PathTo[Robot] = new PathTo[Robot] {
-      override final def self(id: String): Uri = "/robots" / id
+      override def root: Uri = "/robots"
     }
     implicit val robotJsonApiFormat: JsonApiFormat[Robot] = jsonApiFormat[Robot]
 
@@ -109,7 +109,7 @@ final class CoproductSpec extends Specification {
       ResourceType[AdvancedRobot]("advanced-robots")
     implicit val advancedRobotIdentifiable: Identifiable[AdvancedRobot] = Identifiable.by(_.id)
     implicit val advancedRobotPathTo: PathTo[AdvancedRobot] = new PathTo[AdvancedRobot] {
-      override final def self(id: String): Uri = "/advanced-robots" / id
+      override def root: Uri = "/advanced-robots"
     }
     implicit val advancedRobotJsonApiFormat: JsonApiFormat[AdvancedRobot] = jsonApiFormat[AdvancedRobot]
 

--- a/core/src/test/scala/com/qvantel/jsonapi/MacrosSpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/MacrosSpec.scala
@@ -158,7 +158,7 @@ final class MacrosSpec extends Specification with ScalaCheck {
       implicit val resourceType: com.qvantel.jsonapi.ResourceType[Root] = ResourceType[Root]("root")
 
       implicit val pathTo: PathTo[Root] = new PathTo[Root] {
-        override final def self(id: String): Uri = "/roots" / id
+        override final def root: Uri = "/roots"
       }
 
       val format = jsonApiFormat[Root]
@@ -184,7 +184,7 @@ final class MacrosSpec extends Specification with ScalaCheck {
       object End {
         implicit lazy val endResourceType: com.qvantel.jsonapi.ResourceType[End] = ResourceType[End]("end")
         implicit lazy val endPathTo: PathTo[End] = new PathTo[End] {
-          override final def self(id: String): Uri = "/end" / id
+          override final def root: Uri = "/end"
         }
         implicit lazy val endFormat: com.qvantel.jsonapi.JsonApiFormat[End] = jsonApiFormat[End]
         implicit lazy val endIncludes: Includes[End]                        = includes[End]
@@ -193,7 +193,7 @@ final class MacrosSpec extends Specification with ScalaCheck {
       object Leaf {
         implicit lazy val leafResourceType: com.qvantel.jsonapi.ResourceType[Leaf] = ResourceType[Leaf]("leaves")
         implicit lazy val leafPathTo: PathTo[Leaf] = new PathTo[Leaf] {
-          override final def self(id: String): Uri = "/leaves" / id
+          override final def root: Uri = "/leaves"
         }
         implicit lazy val leafFormat: com.qvantel.jsonapi.JsonApiFormat[Leaf] = jsonApiFormat[Leaf]
         implicit lazy val leafIncludes: Includes[Leaf]                        = includes[Leaf]
@@ -202,7 +202,7 @@ final class MacrosSpec extends Specification with ScalaCheck {
       object Child {
         implicit lazy val childResourceType: com.qvantel.jsonapi.ResourceType[Child] = ResourceType[Child]("children")
         implicit lazy val childPathTo: PathTo[Child] = new PathTo[Child] {
-          override final def self(id: String): Uri = "/children" / id
+          override final def root: Uri = "/children"
         }
         implicit lazy val childFormat: com.qvantel.jsonapi.JsonApiFormat[Child] = jsonApiFormat[Child]
         implicit lazy val childIncludes: Includes[Child]                        = includes[Child]
@@ -211,7 +211,7 @@ final class MacrosSpec extends Specification with ScalaCheck {
       object Root {
         implicit lazy val rootResourceType: com.qvantel.jsonapi.ResourceType[Root] = ResourceType[Root]("roots")
         implicit lazy val rootPathTo: PathTo[Root] = new PathTo[Root] {
-          override final def self(id: String): Uri = "/roots" / id
+          override final def root: Uri = "/roots"
         }
         implicit lazy val rootFormat: com.qvantel.jsonapi.JsonApiFormat[Root] = jsonApiFormat[Root]
         implicit lazy val rootIncludes: Includes[Root]                        = includes[Root]

--- a/core/src/test/scala/com/qvantel/jsonapi/PathToSpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/PathToSpec.scala
@@ -1,0 +1,30 @@
+package com.qvantel.jsonapi
+
+import org.specs2.mutable.Specification
+import com.netaporter.uri.dsl._
+import _root_.spray.json.DefaultJsonProtocol._
+
+class PathToSpec extends Specification {
+  implicit val apiRoot = ApiRoot(Some("foo" / "bar"))
+
+  @jsonApiResource final case class Test(id: String)
+
+  "apiRoot should be printed to PathTo output" >> {
+    val t = Test("1")
+
+    PathTo[Test].entity(t) must be equalTo "/foo/bar/tests/1"
+    PathTo[Test].self("test") must be equalTo "/foo/bar/tests/test"
+
+    rawOne(t)
+      .fields("data")
+      .asJsObject
+      .fields("links")
+      .asJsObject
+      .fields("self")
+      .convertTo[String] must be equalTo "/foo/bar/tests/1"
+  }
+
+  "root should print out apiRoot" >> {
+    PathTo[Test].root must be equalTo "/foo/bar/tests"
+  }
+}

--- a/spray/src/test/scala/com/qvantel/jsonapi/spray/JsonApiSupportSpec.scala
+++ b/spray/src/test/scala/com/qvantel/jsonapi/spray/JsonApiSupportSpec.scala
@@ -58,7 +58,7 @@ final class JsonApiSupportSpec extends Specification with Specs2RouteTest with H
     implicit val resourceType: ResourceType[Root] = ResourceType[Root]("root")
     implicit val identifiable: Identifiable[Root] = Identifiable.by(_.id)
     implicit val pathTo: PathTo[Root] = new PathTo[Root] {
-      override final def self(id: String): Uri = "/roots" / id
+      override def root: Uri = "/roots"
     }
     implicit val format: JsonApiFormat[Root] = jsonApiFormat[Root]
   }
@@ -69,7 +69,7 @@ final class JsonApiSupportSpec extends Specification with Specs2RouteTest with H
     implicit val resourceType: ResourceType[Child] = ResourceType[Child]("child")
     implicit val identifiable: Identifiable[Child] = Identifiable.by(_.id)
     implicit val pathTo: PathTo[Child] = new PathTo[Child] {
-      override final def self(id: String): Uri = "/children" / id
+      override def root: Uri = "/children"
     }
     implicit val format: JsonApiFormat[Child] = jsonApiFormat[Child]
   }
@@ -80,7 +80,7 @@ final class JsonApiSupportSpec extends Specification with Specs2RouteTest with H
     implicit val resourceType: ResourceType[Article] = ResourceType[Article]("article")
     implicit val identifiable: Identifiable[Article] = Identifiable.by(_.id)
     implicit val pathTo: PathTo[Article] = new PathTo[Article] {
-      override final def self(id: String): Uri = "/articles" / id
+      override def root: Uri = "/articles"
     }
     implicit val format: JsonApiFormat[Article] = jsonApiFormat[Article]
   }


### PR DESCRIPTION
With this change the PathTo should always give correct paths