### PR TITLE
Add support for user-specified HTTP headers

### DIFF
--- a/akka-client/src/main/scala/com/qvantel/jsonapi/client/akka/AkkaClient.scala
+++ b/akka-client/src/main/scala/com/qvantel/jsonapi/client/akka/AkkaClient.scala
@@ -53,10 +53,11 @@ object AkkaClient {
 
       override def one[A](id: String, include: Set[String] = Set.empty)(implicit pt: PathToId[A],
                                                                         reader: JsonApiReader[A]): IO[Option[A]] =
-        endpoint.uri.flatMap { baseUri =>
+        endpoint.config.flatMap { endpointConfig =>
+          val baseUri = endpointConfig.uri
           val reqUri = baseUri / pt.self(id)
 
-          mkRequest(addInclude(reqUri, include).toString).flatMap(respToEntity(_, include))
+          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers)).flatMap(respToEntity(_, include))
         }
 
       override def many[A](ids: Set[String], include: Set[String])(implicit pt: PathToId[A],
@@ -73,33 +74,37 @@ object AkkaClient {
       }
 
       override def pathOne[A](path: uri.Uri, include: Set[String])(implicit reader: JsonApiReader[A]) =
-        endpoint.uri.flatMap { baseUri =>
+        endpoint.config.flatMap { endpointConfig =>
+          val baseUri = endpointConfig.uri
           val reqUri = baseUri.copy(pathParts = path.pathParts)
 
-          mkRequest(addInclude(reqUri, include).toString).flatMap(respToEntity(_, include))
+          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers)).flatMap(respToEntity(_, include))
         }
 
       override def pathMany[A](path: uri.Uri, include: Set[String])(implicit reader: JsonApiReader[A]) =
-        endpoint.uri.flatMap { baseUri =>
+        endpoint.config.flatMap { endpointConfig =>
+          val baseUri = endpointConfig.uri
           val reqUri = baseUri.copy(pathParts = path.pathParts)
 
-          mkRequest(addInclude(reqUri, include).toString).flatMap(respoToEntities(_, include))
+          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers)).flatMap(respoToEntities(_, include))
         }
 
       override def filter[A](filter: String, include: Set[String])(implicit pt: PathTo[A], reader: JsonApiReader[A]) =
-        endpoint.uri.flatMap { baseUri =>
+        endpoint.config.flatMap { endpointConfig =>
+          val baseUri = endpointConfig.uri
           val reqUri = baseUri / pt.root ? ("filter" -> filter)
 
-          mkRequest(addInclude(reqUri, include).toString).flatMap(respoToEntities(_, include))
+          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers)).flatMap(respoToEntities(_, include))
         }
 
       override def post[A, Response](entity: A, include: Set[String])(implicit pt: PathTo[A],
                                                                       writer: JsonApiWriter[A],
                                                                       reader: JsonApiReader[Response]): IO[Response] =
-        endpoint.uri.flatMap { baseUri =>
+        endpoint.config.flatMap { endpointConfig =>
+          val baseUri = endpointConfig.uri
           val reqUri = baseUri / pt.entity(entity)
 
-          mkRequest(reqUri.toString, HttpMethods.POST, HttpEntity(rawOne(entity).compactPrint)).flatMap { resp =>
+          mkRequest(reqUri.toString, HttpMethods.POST, HttpEntity(rawOne(entity).compactPrint), httpHeaders(endpointConfig.headers)).flatMap { resp =>
             if (resp.status.isSuccess()) {
               bodyToJsObject(resp).map(readOne[Response])
             } else {
@@ -111,10 +116,11 @@ object AkkaClient {
       override def put[A, Response](entity: A, include: Set[String])(implicit pt: PathTo[A],
                                                                      writer: JsonApiWriter[A],
                                                                      reader: JsonApiReader[Response]): IO[Response] =
-        endpoint.uri.flatMap { baseUri =>
+        endpoint.config.flatMap { endpointConfig =>
+          val baseUri = endpointConfig.uri
           val reqUri = baseUri / pt.entity(entity)
 
-          mkRequest(reqUri.toString, HttpMethods.PUT, HttpEntity(rawOne(entity).compactPrint)).flatMap { resp =>
+          mkRequest(reqUri.toString, HttpMethods.PUT, HttpEntity(rawOne(entity).compactPrint), httpHeaders(endpointConfig.headers)).flatMap { resp =>
             if (resp.status.isSuccess()) {
               bodyToJsObject(resp).map(readOne[Response])
             } else {
@@ -126,10 +132,11 @@ object AkkaClient {
       override def patch[A, Response](entity: A, include: Set[String])(implicit pt: PathTo[A],
                                                                        writer: JsonApiWriter[A],
                                                                        reader: JsonApiReader[Response]): IO[Response] =
-        endpoint.uri.flatMap { baseUri =>
+        endpoint.config.flatMap { endpointConfig =>
+          val baseUri = endpointConfig.uri
           val reqUri = baseUri / pt.entity(entity)
 
-          mkRequest(reqUri.toString, HttpMethods.PATCH, HttpEntity(rawOne(entity).compactPrint)).flatMap { resp =>
+          mkRequest(reqUri.toString, HttpMethods.PATCH, HttpEntity(rawOne(entity).compactPrint), httpHeaders(endpointConfig.headers)).flatMap { resp =>
             if (resp.status.isSuccess()) {
               bodyToJsObject(resp).map(readOne[Response])
             } else {
@@ -140,10 +147,11 @@ object AkkaClient {
 
       override def delete[A, Response](entity: A, include: Set[String])(implicit pt: PathTo[A],
                                                                         reader: JsonApiReader[Response]): IO[Response] =
-        endpoint.uri.flatMap { baseUri =>
+        endpoint.config.flatMap { endpointConfig =>
+          val baseUri = endpointConfig.uri
           val reqUri = baseUri / pt.entity(entity)
 
-          mkRequest(reqUri.toString, HttpMethods.DELETE).flatMap { resp =>
+          mkRequest(reqUri.toString, HttpMethods.DELETE, headers = httpHeaders(endpointConfig.headers)).flatMap { resp =>
             if (resp.status.isSuccess()) {
               bodyToJsObject(resp).map(readOne[Response])
             } else {
@@ -163,7 +171,8 @@ object AkkaClient {
 
   private[this] def mkRequest(reqUri: String,
                               method: HttpMethod = HttpMethods.GET,
-                              entity: RequestEntity = HttpEntity.Empty)(implicit m: ActorMaterializer,
+                              entity: RequestEntity = HttpEntity.Empty,
+                              headers: List[HttpHeader])(implicit m: ActorMaterializer,
                                                                         system: ActorSystem): IO[HttpResponse] = {
     import system.dispatcher
 
@@ -173,7 +182,7 @@ object AkkaClient {
           .singleRequest(
             HttpRequest(
               uri = Uri(reqUri),
-              headers = encodings,
+              headers = encodings ++ headers,
               method = method,
               entity = entity
             )
@@ -198,6 +207,16 @@ object AkkaClient {
   }
 
   private[this] val mt: MediaType = MediaType.customWithOpenCharset("application", "vnd.api+json")
+
+  private[this] def httpHeaders(headers: Map[String, String]): List[HttpHeader] = {
+    headers.map { pair =>
+      val (name, value) = pair
+      HttpHeader.parse(name, value) match {
+        case HttpHeader.ParsingResult.Ok(header, _) => header
+        case _                                      => throw new Exception("this should not happen")
+      }
+    }.toList
+  }
 
   private[this] def decodeResponse(response: HttpResponse): HttpResponse = {
     val decoder = response.encoding match {

--- a/akka-client/src/main/scala/com/qvantel/jsonapi/client/akka/AkkaClient.scala
+++ b/akka-client/src/main/scala/com/qvantel/jsonapi/client/akka/AkkaClient.scala
@@ -55,9 +55,10 @@ object AkkaClient {
                                                                         reader: JsonApiReader[A]): IO[Option[A]] =
         endpoint.config.flatMap { endpointConfig =>
           val baseUri = endpointConfig.uri
-          val reqUri = baseUri / pt.self(id)
+          val reqUri  = baseUri / pt.self(id)
 
-          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers)).flatMap(respToEntity(_, include))
+          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers))
+            .flatMap(respToEntity(_, include))
         }
 
       override def many[A](ids: Set[String], include: Set[String])(implicit pt: PathToId[A],
@@ -76,25 +77,28 @@ object AkkaClient {
       override def pathOne[A](path: uri.Uri, include: Set[String])(implicit reader: JsonApiReader[A]) =
         endpoint.config.flatMap { endpointConfig =>
           val baseUri = endpointConfig.uri
-          val reqUri = baseUri.copy(pathParts = path.pathParts)
+          val reqUri  = baseUri.copy(pathParts = path.pathParts)
 
-          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers)).flatMap(respToEntity(_, include))
+          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers))
+            .flatMap(respToEntity(_, include))
         }
 
       override def pathMany[A](path: uri.Uri, include: Set[String])(implicit reader: JsonApiReader[A]) =
         endpoint.config.flatMap { endpointConfig =>
           val baseUri = endpointConfig.uri
-          val reqUri = baseUri.copy(pathParts = path.pathParts)
+          val reqUri  = baseUri.copy(pathParts = path.pathParts)
 
-          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers)).flatMap(respoToEntities(_, include))
+          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers))
+            .flatMap(respoToEntities(_, include))
         }
 
       override def filter[A](filter: String, include: Set[String])(implicit pt: PathTo[A], reader: JsonApiReader[A]) =
         endpoint.config.flatMap { endpointConfig =>
           val baseUri = endpointConfig.uri
-          val reqUri = baseUri / pt.root ? ("filter" -> filter)
+          val reqUri  = baseUri / pt.root ? ("filter" -> filter)
 
-          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers)).flatMap(respoToEntities(_, include))
+          mkRequest(addInclude(reqUri, include).toString, headers = httpHeaders(endpointConfig.headers))
+            .flatMap(respoToEntities(_, include))
         }
 
       override def post[A, Response](entity: A, include: Set[String])(implicit pt: PathTo[A],
@@ -102,9 +106,12 @@ object AkkaClient {
                                                                       reader: JsonApiReader[Response]): IO[Response] =
         endpoint.config.flatMap { endpointConfig =>
           val baseUri = endpointConfig.uri
-          val reqUri = baseUri / pt.entity(entity)
+          val reqUri  = baseUri / pt.entity(entity)
 
-          mkRequest(reqUri.toString, HttpMethods.POST, HttpEntity(rawOne(entity).compactPrint), httpHeaders(endpointConfig.headers)).flatMap { resp =>
+          mkRequest(reqUri.toString,
+                    HttpMethods.POST,
+                    HttpEntity(rawOne(entity).compactPrint),
+                    httpHeaders(endpointConfig.headers)).flatMap { resp =>
             if (resp.status.isSuccess()) {
               bodyToJsObject(resp).map(readOne[Response])
             } else {
@@ -118,9 +125,12 @@ object AkkaClient {
                                                                      reader: JsonApiReader[Response]): IO[Response] =
         endpoint.config.flatMap { endpointConfig =>
           val baseUri = endpointConfig.uri
-          val reqUri = baseUri / pt.entity(entity)
+          val reqUri  = baseUri / pt.entity(entity)
 
-          mkRequest(reqUri.toString, HttpMethods.PUT, HttpEntity(rawOne(entity).compactPrint), httpHeaders(endpointConfig.headers)).flatMap { resp =>
+          mkRequest(reqUri.toString,
+                    HttpMethods.PUT,
+                    HttpEntity(rawOne(entity).compactPrint),
+                    httpHeaders(endpointConfig.headers)).flatMap { resp =>
             if (resp.status.isSuccess()) {
               bodyToJsObject(resp).map(readOne[Response])
             } else {
@@ -134,9 +144,12 @@ object AkkaClient {
                                                                        reader: JsonApiReader[Response]): IO[Response] =
         endpoint.config.flatMap { endpointConfig =>
           val baseUri = endpointConfig.uri
-          val reqUri = baseUri / pt.entity(entity)
+          val reqUri  = baseUri / pt.entity(entity)
 
-          mkRequest(reqUri.toString, HttpMethods.PATCH, HttpEntity(rawOne(entity).compactPrint), httpHeaders(endpointConfig.headers)).flatMap { resp =>
+          mkRequest(reqUri.toString,
+                    HttpMethods.PATCH,
+                    HttpEntity(rawOne(entity).compactPrint),
+                    httpHeaders(endpointConfig.headers)).flatMap { resp =>
             if (resp.status.isSuccess()) {
               bodyToJsObject(resp).map(readOne[Response])
             } else {
@@ -149,14 +162,15 @@ object AkkaClient {
                                                                         reader: JsonApiReader[Response]): IO[Response] =
         endpoint.config.flatMap { endpointConfig =>
           val baseUri = endpointConfig.uri
-          val reqUri = baseUri / pt.entity(entity)
+          val reqUri  = baseUri / pt.entity(entity)
 
-          mkRequest(reqUri.toString, HttpMethods.DELETE, headers = httpHeaders(endpointConfig.headers)).flatMap { resp =>
-            if (resp.status.isSuccess()) {
-              bodyToJsObject(resp).map(readOne[Response])
-            } else {
-              bodyToError(resp)
-            }
+          mkRequest(reqUri.toString, HttpMethods.DELETE, headers = httpHeaders(endpointConfig.headers)).flatMap {
+            resp =>
+              if (resp.status.isSuccess()) {
+                bodyToJsObject(resp).map(readOne[Response])
+              } else {
+                bodyToError(resp)
+              }
           }
         }
     }
@@ -169,11 +183,11 @@ object AkkaClient {
       orig ? ("include" -> include.mkString(","))
     }
 
-  private[this] def mkRequest(reqUri: String,
-                              method: HttpMethod = HttpMethods.GET,
-                              entity: RequestEntity = HttpEntity.Empty,
-                              headers: List[HttpHeader])(implicit m: ActorMaterializer,
-                                                                        system: ActorSystem): IO[HttpResponse] = {
+  private[this] def mkRequest(
+      reqUri: String,
+      method: HttpMethod = HttpMethods.GET,
+      entity: RequestEntity = HttpEntity.Empty,
+      headers: List[HttpHeader])(implicit m: ActorMaterializer, system: ActorSystem): IO[HttpResponse] = {
     import system.dispatcher
 
     IO.fromFuture {
@@ -208,7 +222,7 @@ object AkkaClient {
 
   private[this] val mt: MediaType = MediaType.customWithOpenCharset("application", "vnd.api+json")
 
-  private[this] def httpHeaders(headers: Map[String, String]): List[HttpHeader] = {
+  private[this] def httpHeaders(headers: Map[String, String]): List[HttpHeader] =
     headers.map { pair =>
       val (name, value) = pair
       HttpHeader.parse(name, value) match {
@@ -216,7 +230,6 @@ object AkkaClient {
         case _                                      => throw new Exception("this should not happen")
       }
     }.toList
-  }
 
   private[this] def decodeResponse(response: HttpResponse): HttpResponse = {
     val decoder = response.encoding match {

--- a/akka-client/src/test/scala/com/qvantel/jsonapi/client/akka/AkkaClientSpec.scala
+++ b/akka-client/src/test/scala/com/qvantel/jsonapi/client/akka/AkkaClientSpec.scala
@@ -27,7 +27,7 @@ class AkkaClientSpec(implicit ee: ExecutionEnv) extends Specification with Match
 
   implicit val system: ActorSystem   = ActorSystem()
   implicit val m: ActorMaterializer  = ActorMaterializer()
-  implicit val endpoint: ApiEndpoint = ApiEndpoint.Static("http://localhost:8080/api")
+  implicit val endpoint: ApiEndpoint = ApiEndpoint.Static("http://localhost:8080/api", Map())
 
   val jac = JsonApiClient.instance
 

--- a/core/src/main/scala/com/qvantel/jsonapi/ApiEndpoint.scala
+++ b/core/src/main/scala/com/qvantel/jsonapi/ApiEndpoint.scala
@@ -2,14 +2,17 @@ package com.qvantel.jsonapi
 
 import cats.effect.IO
 import com.netaporter.uri.Uri
+import com.qvantel.jsonapi.ApiEndpoint.Config
 
 trait ApiEndpoint {
-  def uri: IO[Uri]
+  def config: IO[Config]
 }
 
 object ApiEndpoint {
-  final case class Static(static: Uri) extends ApiEndpoint {
-    override val uri: IO[Uri] = IO.pure(static)
+  final case class Config(uri: Uri, headers: Map[String, String])
+
+  final case class Static(static: Uri, headers: Map[String, String] = Map()) extends ApiEndpoint {
+    override val config: IO[Config] = IO.pure(Config(static, headers))
   }
-  final case class Dynamic(uri: IO[Uri]) extends ApiEndpoint
+  final case class Dynamic(config: IO[Config]) extends ApiEndpoint
 }

--- a/http4s-client/src/main/scala/com/qvantel/jsonapi/client/http4s/Http4sClient.scala
+++ b/http4s-client/src/main/scala/com/qvantel/jsonapi/client/http4s/Http4sClient.scala
@@ -32,7 +32,7 @@ trait Http4sClient extends Http4sClientDsl[IO] {
     override def one[A](id: String, include: Set[String] = Set.empty)(implicit pt: PathToId[A],
                                                                       reader: JsonApiReader[A]): IO[Option[A]] =
       for {
-        config <- endpoint.config
+        config   <- endpoint.config
         response <- pathOne(config.uri / pt.self(id), include)
       } yield response
 
@@ -54,7 +54,7 @@ trait Http4sClient extends Http4sClientDsl[IO] {
         uri <- IO.fromEither(
           org.http4s.Uri
             .fromString(config.uri / pt.root ? ("filter" -> filter) ? ("include" -> mkIncludeString(include))))
-        response <- client.expect[List[A]](GET(uri, httpHeaders(config.headers):_*))
+        response <- client.expect[List[A]](GET(uri, httpHeaders(config.headers): _*))
       } yield response
     }
 
@@ -67,7 +67,7 @@ trait Http4sClient extends Http4sClientDsl[IO] {
         uri <- IO.fromEither(
           org.http4s.Uri
             .fromString(config.uri.copy(pathParts = path.pathParts) ? ("include" -> mkIncludeString(include))))
-        req <- GET(uri, httpHeaders(config.headers):_*)
+        req <- GET(uri, httpHeaders(config.headers): _*)
       } yield req
 
       client.fetch(request) {
@@ -86,7 +86,7 @@ trait Http4sClient extends Http4sClientDsl[IO] {
         uri <- IO.fromEither(
           org.http4s.Uri
             .fromString(config.uri.copy(pathParts = path.pathParts) ? ("include" -> mkIncludeString(include))))
-        response <- client.expect[List[A]](GET(uri, httpHeaders(config.headers):_*))
+        response <- client.expect[List[A]](GET(uri, httpHeaders(config.headers): _*))
       } yield response
     }
 
@@ -101,7 +101,7 @@ trait Http4sClient extends Http4sClientDsl[IO] {
         uri <- IO.fromEither(
           org.http4s.Uri
             .fromString(config.uri / pt.entity(entity)))
-        req <- POST(uri, entity, httpHeaders(config.headers):_*)
+        req <- POST(uri, entity, httpHeaders(config.headers): _*)
       } yield req
 
       client.fetch(request) {
@@ -121,7 +121,7 @@ trait Http4sClient extends Http4sClientDsl[IO] {
         uri <- IO.fromEither(
           org.http4s.Uri
             .fromString(config.uri / pt.entity(entity)))
-        req      <- PUT(uri, entity, httpHeaders(config.headers):_*)
+        req      <- PUT(uri, entity, httpHeaders(config.headers): _*)
         response <- client.fetchAs[Response](req)
       } yield response
     }
@@ -137,7 +137,7 @@ trait Http4sClient extends Http4sClientDsl[IO] {
         uri <- IO.fromEither(
           org.http4s.Uri
             .fromString(config.uri / pt.entity(entity)))
-        req      <- PATCH(uri, entity, httpHeaders(config.headers):_*)
+        req      <- PATCH(uri, entity, httpHeaders(config.headers): _*)
         response <- client.fetchAs[Response](req)
       } yield response
     }
@@ -152,7 +152,7 @@ trait Http4sClient extends Http4sClientDsl[IO] {
         uri <- IO.fromEither(
           org.http4s.Uri
             .fromString(config.uri / pt.entity(entity)))
-        req      <- DELETE(uri, httpHeaders(config.headers):_*)
+        req      <- DELETE(uri, httpHeaders(config.headers): _*)
         response <- client.fetchAs[Response](req)
       } yield response
     }

--- a/http4s-client/src/test/scala/com/qvantel/jsonapi/client/http4s/Http4sClientSpec.scala
+++ b/http4s-client/src/test/scala/com/qvantel/jsonapi/client/http4s/Http4sClientSpec.scala
@@ -108,7 +108,7 @@ class Http4sClientSpec extends Specification with MatcherMacros {
       Ok(customerAccounts("ca1").copy(id = "delete"))
   }
 
-  implicit val endpoint: ApiEndpoint = ApiEndpoint.Static("http://localhost:8080")
+  implicit val endpoint: ApiEndpoint = ApiEndpoint.Static("http://localhost:8080", Map())
   implicit val client: Client[IO]    = Client.fromHttpService(service)
 
   val jac = JsonApiClient.instance


### PR DESCRIPTION
This PR adds support for user's of the library to specify additional arbitrary HTTP headers for the akka-client and http4s-client. 

My use case is authenticating to a JSONAPI server with a bearer token, which uses the 'Authorization' HTTP header.

In core, I chose to type the headers as Map[String, String] to stay agnostic of either http library's header implementation. Within each client, the appropriate Header type is used.

ApiEndpoint seemed like the logical place to specify headers, so I modified that class slightly to use IO[Config] instead of IO[Uri]. Config contains the endpoint uri and headers. I made the headers parameter optional to preserve backwards compatibility.

I wasn't sure how to add this functionality to the tests, though I can take a shot at that with a little guidance. I am now using this fork of the library with a production JSONAPI server with the Authorization header, and everything works as expected.