### PR TITLE
Bugfix/akka

### DIFF
--- a/akka/src/main/scala/com/qvantel/jsonapi/akka/AkkaExceptionHandler.scala
+++ b/akka/src/main/scala/com/qvantel/jsonapi/akka/AkkaExceptionHandler.scala
@@ -168,22 +168,9 @@ trait AkkaExceptionHandlerTrait {
 
 object AkkaExceptionHandlerObject extends Rejection {
 
-  val noneHandler: Directive0 = mapResponse {
-    case HttpResponse(OK, _, HttpEntity.Empty, _) =>
-      jsonApiErrorResponse(NotFound, NotFound.reason, NotFound.defaultMessage)
-  }
-
   def jsonApiError(code: StatusCode, title: String, detail: String): JsValue =
-    JsObject(
-      "errors" -> List(
-        ErrorObject(id = None,
-                    links = Map.empty,
-                    status = Some(code.intValue.toString),
-                    code = None,
-                    title = Some(title),
-                    detail = Some(detail),
-                    source = None,
-                    meta = Map.empty)).toJson)
+    JsObject("errors" -> List(
+      ErrorObject(status = Some(code.intValue.toString), title = Some(title), detail = Some(detail))).toJson)
 
   def jsonApiErrorResponse(code: StatusCode, title: String, detail: String): HttpResponse =
     HttpResponse(

--- a/akka/src/main/scala/com/qvantel/jsonapi/akka/JsonApiSupport.scala
+++ b/akka/src/main/scala/com/qvantel/jsonapi/akka/JsonApiSupport.scala
@@ -39,7 +39,7 @@ import _root_.akka.stream.Materializer
 import _root_.akka.stream.scaladsl._
 import _root_.akka.util.{ByteString, Timeout}
 
-import com.qvantel.jsonapi.model.TopLevel
+import com.qvantel.jsonapi.model.{ErrorObjects, TopLevel}
 
 trait JsonApiSupport extends JsonApiSupport0 {
 
@@ -99,6 +99,12 @@ trait JsonApiSupport0 {
   implicit val jsonApiTopLevelCollection: Unmarshaller[HttpEntity, TopLevel.Collection] = {
     Unmarshaller.byteStringUnmarshaller.map { data =>
       JsonParser(data.utf8String).asJsObject.convertTo[TopLevel.Collection]
+    }
+  }
+
+  implicit val jsonApiErrorObject: Unmarshaller[HttpEntity, ErrorObjects] = {
+    Unmarshaller.byteStringUnmarshaller.map { data =>
+      JsonParser(data.utf8String).asJsObject.convertTo[ErrorObjects]
     }
   }
 

--- a/akka/src/main/scala/com/qvantel/jsonapi/akka/JsonApiSupport.scala
+++ b/akka/src/main/scala/com/qvantel/jsonapi/akka/JsonApiSupport.scala
@@ -28,9 +28,7 @@ package com.qvantel.jsonapi.akka
 
 import com.qvantel.jsonapi._
 import scala.concurrent.{ExecutionContext, Future}
-
 import _root_.spray.json._
-
 import _root_.akka.http.scaladsl.marshalling._
 import _root_.akka.http.scaladsl.unmarshalling._
 import _root_.akka.http.scaladsl.Http
@@ -40,6 +38,8 @@ import _root_.akka.http.scaladsl.model.headers._
 import _root_.akka.stream.Materializer
 import _root_.akka.stream.scaladsl._
 import _root_.akka.util.{ByteString, Timeout}
+
+import com.qvantel.jsonapi.model.TopLevel
 
 trait JsonApiSupport extends JsonApiSupport0 {
 
@@ -89,6 +89,18 @@ trait JsonApiSupport extends JsonApiSupport0 {
 
 trait JsonApiSupport0 {
   val ct = MediaTypes.`application/vnd.api+json`
+
+  implicit val jsonApiTopLevelSingle: Unmarshaller[HttpEntity, TopLevel.Single] = {
+    Unmarshaller.byteStringUnmarshaller.map { data =>
+      JsonParser(data.utf8String).asJsObject.convertTo[TopLevel.Single]
+    }
+  }
+
+  implicit val jsonApiTopLevelCollection: Unmarshaller[HttpEntity, TopLevel.Collection] = {
+    Unmarshaller.byteStringUnmarshaller.map { data =>
+      JsonParser(data.utf8String).asJsObject.convertTo[TopLevel.Collection]
+    }
+  }
 
   implicit def jsonApiOneMarshaller[T](implicit writer: JsonApiWriter[T],
                                        printer: JsonPrinter = PrettyPrinter,

--- a/akka/src/test/scala/com/qvantel/jsonapi/akka/JsonApiSupportSpec.scala
+++ b/akka/src/test/scala/com/qvantel/jsonapi/akka/JsonApiSupportSpec.scala
@@ -28,7 +28,6 @@ package com.qvantel.jsonapi.akka
 
 import com.qvantel.jsonapi._
 import com.qvantel.jsonapi.akka.JsonApiSupport._
-
 import _root_.spray.json._
 import _root_.spray.json.DefaultJsonProtocol._
 import _root_.akka.http.scaladsl.model._
@@ -40,6 +39,8 @@ import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import org.specs2.mutable.Specification
 import shapeless._
+
+import com.qvantel.jsonapi.model.TopLevel
 
 final class JsonApiSupportSpec extends Specification with Specs2RouteTest {
   val ct = ContentType(MediaTypes.`application/vnd.api+json`)
@@ -585,6 +586,57 @@ final class JsonApiSupportSpec extends Specification with Specs2RouteTest {
 
         loaded must be equalTo A("b1", ToOne.reference("b2"))
       }.exactly(1.times)
+    }
+    "unmarshal TopLevel.Single" in {
+
+      val route = get {
+        complete(
+          HttpResponse(
+            status = StatusCodes.BadRequest,
+            entity = HttpEntity(
+              MediaTypes.`application/vnd.api+json`,
+              TopLevel
+                .Single(
+                  data = None,
+                  links = Map.empty,
+                  meta = Map.empty,
+                  jsonapi = None,
+                  included = Map.empty
+                )
+                .toJson
+                .prettyPrint
+            )
+          ))
+      }
+      Get("/") ~> route ~> check {
+        val single = responseAs[TopLevel.Single]
+        single.data must beNone
+      }
+    }
+    "unmarshal TopLevel.Collection" in {
+      val route = get {
+        complete(
+          HttpResponse(
+            status = StatusCodes.BadRequest,
+            entity = HttpEntity(
+              MediaTypes.`application/vnd.api+json`,
+              TopLevel
+                .Collection(
+                  data = Map.empty,
+                  links = Map.empty,
+                  meta = Map.empty,
+                  jsonapi = None,
+                  included = Map.empty
+                )
+                .toJson
+                .prettyPrint
+            )
+          ))
+      }
+      Get("/") ~> route ~> check {
+        val collection = responseAs[TopLevel.Collection]
+        collection.data must be empty
+      }
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ val scala211 = Seq(
 
 description in ThisBuild := "jsonapi.org scala implementation"
 
-version in ThisBuild := "8.1.0"
+version in ThisBuild := "8.1.1"
 
 startYear in ThisBuild := Some(2015)
 
@@ -239,10 +239,9 @@ lazy val spray = (project in file("spray"))
       "com.typesafe.akka" %% "akka-actor" % "2.4.20" excludeAll (ExclusionRule(
         organization = "com.typesafe.akka",
         name = "akka-cluster_2.11"), ExclusionRule(organization = "com.typesafe.akka", name = "akka-remote_2.11")),
-      "io.spray"          %% "spray-testkit"             % "1.3.4" % "test",
+      "io.spray"          %% "spray-testkit"             % "1.3.4"  % "test",
       "com.typesafe.akka" %% "akka-testkit"              % "2.4.20" % "test",
-      "io.spray"          %% "spray-routing-shapeless23" % "1.3.4" % "test",
-      "org.scalatest"     %% "scalatest"                 % "3.0.+"
+      "io.spray"          %% "spray-routing-shapeless23" % "1.3.4"  % "test"
     ) ++ testDeps
   )
 
@@ -300,16 +299,15 @@ lazy val akka = (project in file("akka"))
     scalacOptions ++= scala211,
     libraryDependencies ++= Seq(
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-      "com.typesafe.akka" %% "akka-actor" % "2.4.20" excludeAll (ExclusionRule(
+      "com.typesafe.akka" %% "akka-actor" % "2.5.6" excludeAll (ExclusionRule(
         organization = "com.typesafe.akka",
         name = "akka-cluster_2.11"), ExclusionRule(organization = "com.typesafe.akka", name = "akka-remote_2.11")),
       "com.typesafe.akka" %% "akka-testkit"      % "2.4.20" % "test",
       "com.typesafe.akka" %% "akka-stream"       % "2.5.6",
-      "com.typesafe.akka" %% "akka-actor"        % "2.5.6",
-      "com.typesafe.akka" %% "akka-http"         % "10.0.10",
-      "com.typesafe.akka" %% "akka-http-core"    % "10.0.10",
+      "com.typesafe.akka" %% "akka-http"         % "10.1.3",
+      "com.typesafe.akka" %% "akka-http-core"    % "10.1.3",
       "com.typesafe.akka" %% "akka-http-testkit" % "10.1.3",
-      "org.scalatest"     %% "scalatest"         % "3.0.+"
+      "org.scalatest"     %% "scalatest"         % "3.0.4"
     ) ++ testDeps
   )
 

--- a/model/src/main/scala/com/qvantel/jsonapi/model/ErrorObject.scala
+++ b/model/src/main/scala/com/qvantel/jsonapi/model/ErrorObject.scala
@@ -29,6 +29,24 @@ package com.qvantel.jsonapi.model
 import _root_.spray.json.DefaultJsonProtocol._
 import _root_.spray.json._
 
+final case class ErrorObjects(errors: List[ErrorObject])
+
+object ErrorObjects {
+  import ErrorObject.ErrorObjectJsonFormat._
+  implicit object ErrorObjectsJsonFormat extends RootJsonFormat[ErrorObjects] {
+    override def write(obj: ErrorObjects): JsValue = {
+      val builder = Map.newBuilder[String, JsValue]
+      builder += "errors" -> obj.errors.toJson
+      JsObject(builder.result())
+    }
+
+    override def read(json: JsValue): ErrorObjects = {
+      val fields = json.asJsObject.fields
+      ErrorObjects(errors = fields.get("errors").fold(List.empty[ErrorObject])(_.convertTo[List[ErrorObject]]))
+    }
+  }
+}
+
 final case class ErrorObject(id: Option[String] = None,
                              links: Links = Map.empty,
                              status: Option[String] = None,

--- a/model/src/main/scala/com/qvantel/jsonapi/model/ErrorObject.scala
+++ b/model/src/main/scala/com/qvantel/jsonapi/model/ErrorObject.scala
@@ -29,14 +29,14 @@ package com.qvantel.jsonapi.model
 import _root_.spray.json.DefaultJsonProtocol._
 import _root_.spray.json._
 
-final case class ErrorObject(id: Option[String],
-                             links: Links,
-                             status: Option[String],
-                             code: Option[String],
-                             title: Option[String],
-                             detail: Option[String],
-                             source: Option[ErrorSource],
-                             meta: MetaObject)
+final case class ErrorObject(id: Option[String] = None,
+                             links: Links = Map.empty,
+                             status: Option[String] = None,
+                             code: Option[String] = None,
+                             title: Option[String] = None,
+                             detail: Option[String] = None,
+                             source: Option[ErrorSource] = None,
+                             meta: MetaObject = Map.empty)
 
 object ErrorObject {
   implicit object ErrorObjectJsonFormat extends RootJsonFormat[ErrorObject] {


### PR DESCRIPTION
Updating the scalatest lib so that users won't get an unknown version of it.
Also adding akka marshalling for easier test handling. 

'responseAs[TopLevel.Single]'
'responseAs[TopLevel.Collection]'
'responseAs[ErrorObjects]' can now be used with akka-http-test