### PR TITLE
Added support for sparse fieldsets by adapting the JsonApiWriter to the fieldset

### DIFF
--- a/akka/src/main/scala/com/qvantel/jsonapi/akka/JsonApiSupport.scala
+++ b/akka/src/main/scala/com/qvantel/jsonapi/akka/JsonApiSupport.scala
@@ -49,7 +49,8 @@ trait JsonApiSupport extends JsonApiSupport0 {
       implicit writer: JsonApiWriter[T],
       printer: JsonPrinter = PrettyPrinter,
       metaProfiles: Set[MetaProfile] = Set.empty,
-      sorting: JsonApiSorting = JsonApiSorting.Unsorted): ToEntityMarshaller[Iterable[T]] =
+      sorting: JsonApiSorting = JsonApiSorting.Unsorted,
+      sparseFields: Map[String, List[String]] = Map.empty): ToEntityMarshaller[Iterable[T]] =
     Marshaller.withFixedContentType(ct) { as =>
       HttpEntity(ct, rawCollection(as))
     }
@@ -103,7 +104,8 @@ trait JsonApiSupport0 {
   implicit def jsonApiOneMarshaller[T](implicit writer: JsonApiWriter[T],
                                        printer: JsonPrinter = PrettyPrinter,
                                        metaProfiles: Set[MetaProfile] = Set.empty,
-                                       sorting: JsonApiSorting = JsonApiSorting.Unsorted): ToEntityMarshaller[T] =
+                                       sorting: JsonApiSorting = JsonApiSorting.Unsorted,
+                                       sparseFields: Map[String, List[String]] = Map.empty): ToEntityMarshaller[T] =
     Marshaller.withFixedContentType(ct) { a =>
       HttpEntity(ct, rawOne(a))
     }
@@ -111,7 +113,8 @@ trait JsonApiSupport0 {
   implicit def relatedResponseMarshaller[A](
       implicit writer: JsonApiWriter[A],
       printer: JsonPrinter = PrettyPrinter,
-      sorting: JsonApiSorting = JsonApiSorting.Unsorted): ToEntityMarshaller[com.qvantel.jsonapi.RelatedResponse[A]] =
+      sorting: JsonApiSorting = JsonApiSorting.Unsorted,
+      sparseFields: Map[String, List[String]] = Map.empty): ToEntityMarshaller[com.qvantel.jsonapi.RelatedResponse[A]] =
     PredefinedToEntityMarshallers.StringMarshaller.wrap(ct) { value =>
       printer.apply(value.toResponse)
     }

--- a/akka/src/test/scala/com/qvantel/jsonapi/JsonApiSortingAkkaSpec.scala
+++ b/akka/src/test/scala/com/qvantel/jsonapi/JsonApiSortingAkkaSpec.scala
@@ -54,9 +54,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
     """
       |{
       |  "data": {
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "data": [{
@@ -78,9 +75,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       |    "type": "res"
       |  },
       |  "included": [{
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -94,9 +88,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       |    "id": "3",
       |    "type": "res"
       |  }, {
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -117,9 +108,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
     """
       |{
       |  "data": [{
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -133,9 +121,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       |    "id": "1",
       |    "type": "res"
       |  }, {
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -149,9 +134,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       |    "id": "3",
       |    "type": "res"
       |  }, {
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -189,9 +171,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       """
         |{
         |  "data": {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "data": [{
@@ -213,9 +192,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "type": "res"
         |  },
         |  "included": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -229,9 +205,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -252,9 +225,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       """
         |{
         |  "data": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -268,9 +238,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "1",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -284,9 +251,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -320,9 +284,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       """
         |{
         |  "data": {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "data": [{
@@ -344,9 +305,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "type": "res"
         |  },
         |  "included": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -360,9 +318,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "3",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -383,9 +338,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       """
         |{
         |  "data": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -399,9 +351,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "3",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -415,9 +364,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -452,9 +398,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       """
         |{
         |  "data": {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "data": [{
@@ -476,9 +419,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "type": "res"
         |  },
         |  "included": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -492,9 +432,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -515,9 +452,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       """
         |{
         |  "data": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -531,9 +465,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "1",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -547,9 +478,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -583,9 +511,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       """
         |{
         |  "data": {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "data": [{
@@ -607,9 +532,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "type": "res"
         |  },
         |  "included": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -623,9 +545,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -646,9 +565,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
       """
         |{
         |  "data": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -662,9 +578,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "1",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -678,9 +591,6 @@ final class JsonApiSortingAkkaSpec extends Specification with Specs2RouteTest {
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ val scala211 = Seq(
 
 description in ThisBuild := "jsonapi.org scala implementation"
 
-version in ThisBuild := "8.4.0"
+version in ThisBuild := "9.0.0"
 
 startYear in ThisBuild := Some(2015)
 
@@ -269,8 +269,8 @@ lazy val akkaClient = (project in file("akka-client"))
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
       "com.typesafe.akka" %% "akka-stream"          % "2.5.23",
       "com.typesafe.akka" %% "akka-actor"           % "2.5.23",
-      "com.typesafe.akka" %% "akka-http"            % "10.1.9",
-      "com.typesafe.akka" %% "akka-http-spray-json" % "10.1.9"
+      "com.typesafe.akka" %% "akka-http"            % "10.1.11",
+      "com.typesafe.akka" %% "akka-http-spray-json" % "10.1.11"
     ) ++ testDeps
   )
 
@@ -319,9 +319,9 @@ lazy val akka = (project in file("akka"))
         ExclusionRule(organization = "com.typesafe.akka", name = "akka-remote_2.11")
       ),
       "com.typesafe.akka" %% "akka-stream"       % "2.5.23",
-      "com.typesafe.akka" %% "akka-http"         % "10.1.9",
-      "com.typesafe.akka" %% "akka-http-core"    % "10.1.9",
-      "com.typesafe.akka" %% "akka-http-testkit" % "10.1.9" % Test,
+      "com.typesafe.akka" %% "akka-http"         % "10.1.11",
+      "com.typesafe.akka" %% "akka-http-core"    % "10.1.11",
+      "com.typesafe.akka" %% "akka-http-testkit" % "10.1.11" % Test,
       "org.scalatest"     %% "scalatest"         % "3.0.8" % Test,
       "com.typesafe.akka" %% "akka-testkit"      % "2.5.23" % Test
     ) ++ testDeps

--- a/core/src/main/scala/com/qvantel/jsonapi/JsonApiFormat.scala
+++ b/core/src/main/scala/com/qvantel/jsonapi/JsonApiFormat.scala
@@ -58,7 +58,9 @@ trait JsonApiReader[T] extends RootJsonReader[T] {
 
 @implicitNotFound(msg = "Cannot find JsonApiWriter or JsonApiFormat type class for ${T}")
 trait JsonApiWriter[T] extends RootJsonWriter[T] {
-  def included(obj: T): Set[JsObject]
+  override def write(obj: T): JsValue = write(obj, Map.empty)
+  def included(obj: T, sparseFields: Map[String, List[String]] = Map.empty): Set[JsObject]
+  def write(obj: T, sparseFields: Map[String, List[String]]): JsValue
 }
 
 @implicitNotFound(msg = "Cannot find JsonApiFormat type class for ${T}")

--- a/core/src/main/scala/com/qvantel/jsonapi/Macros.scala
+++ b/core/src/main/scala/com/qvantel/jsonapi/Macros.scala
@@ -59,9 +59,10 @@ final class Macros(val c: blackbox.Context) extends JsonApiWriters with JsonApiR
     val includePath       = TermName(c.freshName("includePath"))
     q"""new _root_.com.qvantel.jsonapi.JsonApiFormat[$t] with _root_.spray.json.RootJsonFormat[$t] {
           import _root_.com.qvantel.jsonapi.PathJsonFormat
-          override final def write($rootParamName: $t): _root_.spray.json.JsValue = ${primaryDataWriter(t,
-                                                                                                        rootParamName)}
-          override final def included($rootParamName: $t): _root_.scala.collection.immutable.Set[_root_.spray.json.JsObject] = ${includedWriter(
+          override final def write($rootParamName: $t, sparseFields: Map[String, List[String]]): _root_.spray.json.JsValue = ${primaryDataWriter(
+      t,
+      rootParamName)}
+          override final def included($rootParamName: $t, sparseFields: Map[String, List[String]]): _root_.scala.collection.immutable.Set[_root_.spray.json.JsObject] = ${includedWriter(
       t,
       rootParamName)}
           override final def read(

--- a/core/src/main/scala/com/qvantel/jsonapi/RelatedResponse.scala
+++ b/core/src/main/scala/com/qvantel/jsonapi/RelatedResponse.scala
@@ -36,7 +36,8 @@ import _root_.spray.json.{JsArray, JsNull, JsObject, JsValue, JsonPrinter, Prett
 sealed trait RelatedResponse[A] {
   def toResponse(implicit writer: JsonApiWriter[A],
                  printer: JsonPrinter = PrettyPrinter,
-                 sorting: JsonApiSorting = JsonApiSorting.Unsorted): JsValue
+                 sorting: JsonApiSorting = JsonApiSorting.Unsorted,
+                 sparseFields: Map[String, List[String]] = Map.empty): JsValue
 
   def map[B](f: A => B): RelatedResponse[B]
 }
@@ -48,7 +49,8 @@ object RelatedResponse {
     final class Empty[A] extends One[A] {
       def toResponse(implicit writer: JsonApiWriter[A],
                      printer: JsonPrinter = PrettyPrinter,
-                     sorting: JsonApiSorting = JsonApiSorting.Unsorted): JsValue = JsObject("data" -> JsNull)
+                     sorting: JsonApiSorting = JsonApiSorting.Unsorted,
+                     sparseFields: Map[String, List[String]] = Map.empty): JsValue = JsObject("data" -> JsNull)
 
       def map[B](f: A => B): RelatedResponse[B] = new Empty[B]
     }
@@ -56,7 +58,8 @@ object RelatedResponse {
     final case class Result[A](data: A) extends One[A] {
       def toResponse(implicit writer: JsonApiWriter[A],
                      printer: JsonPrinter = PrettyPrinter,
-                     sorting: JsonApiSorting = JsonApiSorting.Unsorted): JsValue = rawOne(data)
+                     sorting: JsonApiSorting = JsonApiSorting.Unsorted,
+                     sparseFields: Map[String, List[String]] = Map.empty): JsValue = rawOne(data)
 
       def map[B](f: A => B): RelatedResponse[B] = Result(f(data))
     }
@@ -75,7 +78,8 @@ object RelatedResponse {
     final class Empty[A] extends Many[A] {
       def toResponse(implicit writer: JsonApiWriter[A],
                      printer: JsonPrinter = PrettyPrinter,
-                     sorting: JsonApiSorting = JsonApiSorting.Unsorted): JsValue = JsObject("data" -> JsArray.empty)
+                     sorting: JsonApiSorting = JsonApiSorting.Unsorted,
+                     sparseFields: Map[String, List[String]] = Map.empty): JsValue = JsObject("data" -> JsArray.empty)
 
       def map[B](f: A => B): RelatedResponse[B] = new Empty[B]
     }
@@ -83,7 +87,8 @@ object RelatedResponse {
     final case class Result[A](data: List[A]) extends Many[A] {
       def toResponse(implicit writer: JsonApiWriter[A],
                      printer: JsonPrinter = PrettyPrinter,
-                     sorting: JsonApiSorting = JsonApiSorting.Unsorted): JsValue = rawCollection(data)
+                     sorting: JsonApiSorting = JsonApiSorting.Unsorted,
+                     sparseFields: Map[String, List[String]] = Map.empty): JsValue = rawCollection(data)
 
       def map[B](f: A => B): RelatedResponse[B] = Result(data.map(f))
     }

--- a/core/src/test/scala/com/qvantel/jsonapi/ApiRootSpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/ApiRootSpec.scala
@@ -41,7 +41,6 @@ class ApiRootSpec extends org.specs2.mutable.Specification {
       val json =
         """
           |{
-          |  "attributes":{},
           |  "relationships":{
           |    "rel":{
           |      "data":{

--- a/core/src/test/scala/com/qvantel/jsonapi/CoproductSpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/CoproductSpec.scala
@@ -144,6 +144,22 @@ final class CoproductSpec extends Specification {
       ok
     }
 
+    "at least compile with a sparse fieldset defined" in {
+      val sparseFields: Map[String, List[String]] = Map("robots" -> List("arm"), "advanced-robots" -> List("modules"))
+
+      val pjr1 = implicitly[JsonApiFormat[Robot]].write(Examples.robot1, sparseFields)
+      val pjr2 = implicitly[JsonApiFormat[Robot]].write(Examples.robot2, sparseFields)
+      val pjr3 = implicitly[JsonApiFormat[Robot]].write(Examples.robot3, sparseFields)
+      val ijr1 = implicitly[JsonApiFormat[Robot]].included(Examples.robot1, sparseFields)
+      val ijr2 = implicitly[JsonApiFormat[Robot]].included(Examples.robot2, sparseFields)
+      val ijr3 = implicitly[JsonApiFormat[Robot]].included(Examples.robot3, sparseFields)
+      val pja1 = implicitly[JsonApiFormat[AdvancedRobot]].write(Examples.advancedRobot1, sparseFields)
+      val pja2 = implicitly[JsonApiFormat[AdvancedRobot]].write(Examples.advancedRobot2, sparseFields)
+      val ija1 = implicitly[JsonApiFormat[AdvancedRobot]].included(Examples.advancedRobot1, sparseFields)
+      val ija2 = implicitly[JsonApiFormat[AdvancedRobot]].included(Examples.advancedRobot2, sparseFields)
+      ok
+    }
+
     "includes work" in {
       Eye.eyeIncludes.includesAllowed("friend", "friend.arm", "friend.module") must beTrue
       Robot.robotIncludes.includesAllowed("arm", "module") must beTrue

--- a/core/src/test/scala/com/qvantel/jsonapi/PolyToOneSpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/PolyToOneSpec.scala
@@ -226,9 +226,6 @@ final class PolyToOneSpec extends Specification {
         """
           |{
           |  "data": {
-          |    "attributes": {
-          |
-          |    },
           |    "relationships": {
           |      "maybe": {
           |        "data": null,
@@ -247,6 +244,41 @@ final class PolyToOneSpec extends Specification {
         """.stripMargin.parseJson.asJsObject
 
       rawOne(t) must be equalTo rawJson
+    }
+
+    "correctly write sparse fieldsets (while supporting inclusion of the relationship even if it is not included in the sparse fieldset)" >> {
+      implicit val sparseFields: Map[String, List[String]] = Map("articles" -> List("title"))
+      val article                                          = Article("1", "boom", PolyToOne.loaded[Author, Person](Person("test-id", "mario")))
+
+      val rawJson =
+        """
+          |{
+          |  "data": {
+          |    "attributes": {
+          |      "title": "boom"
+          |    },
+          |    "links": {
+          |      "self":"/articles/1"
+          |    },
+          |    "id": "1",
+          |    "type": "articles"
+          |  },
+          |  "included": [
+          |    {
+          |      "attributes": {
+          |        "name": "mario"
+          |      },
+          |      "id": "test-id",
+          |      "links": {
+          |        "self": "/people/test-id"
+          |      },
+          |      "type": "people"
+          |    }
+          |  ]
+          |}
+        """.stripMargin.parseJson.asJsObject
+
+      rawOne[Article](article) must be equalTo rawJson
     }
   }
 

--- a/core/src/test/scala/com/qvantel/jsonapi/RelatedResponseSpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/RelatedResponseSpec.scala
@@ -9,15 +9,15 @@ import _root_.spray.json.DefaultJsonProtocol._
 class RelatedResponseSpec extends Specification with ScalaCheck {
   implicit val apiRoot: com.qvantel.jsonapi.ApiRoot = ApiRoot(None)
 
-  @jsonApiResource final case class Test(id: String)
-  @jsonApiResource final case class Test2(id: String)
+  @jsonApiResource final case class Test(id: String, name: String, age: Int)
+  @jsonApiResource final case class Test2(id: String, name: String, age: Int)
 
-  val test: Option[Test]      = Some(Test("teståöä•Ωé®")) // test UTF-8
+  val test: Option[Test]      = Some(Test("teståöä•Ωé®", "someName", 20)) // test UTF-8
   val emptyTest: Option[Test] = None
-  val tests: List[Test]       = List(Test("test 1"), Test("test 2"))
+  val tests: List[Test]       = List(Test("test 1", "someName1", 20), Test("test 2", "someName2", 21))
   val emptyTests: List[Test]  = List.empty
 
-  def transformToTest2(in: Test): Test2 = Test2(in.id + "-2")
+  def transformToTest2(in: Test): Test2 = Test2(in.id + "-2", in.name, in.age)
 
   "correctly write to one none case" in {
     RelatedResponse(emptyTest).toResponse must be equalTo JsObject(
@@ -64,5 +64,18 @@ class RelatedResponseSpec extends Specification with ScalaCheck {
     RelatedResponse(tests.toSeq).map(transformToTest2).toResponse must be equalTo transformedAnswer
     RelatedResponse(tests.toIterable).map(transformToTest2).toResponse must be equalTo transformedAnswer
     RelatedResponse(tests.toSet).map(transformToTest2).toResponse must be equalTo transformedAnswer
+  }
+
+  "correctly write sparse fieldsets" in {
+    implicit val sparseFields: Map[String, List[String]] = Map("tests" -> List("age"), "test2s" -> List("age"))
+    val answer                                           = rawOne(test.get)
+
+    RelatedResponse(test).toResponse must be equalTo answer
+    RelatedResponse(test.get).toResponse must be equalTo answer
+
+    val transformedAnswer = rawOne(transformToTest2(test.get))
+
+    RelatedResponse(test).map(transformToTest2).toResponse must be equalTo transformedAnswer
+    RelatedResponse(test.get).map(transformToTest2).toResponse must be equalTo transformedAnswer
   }
 }

--- a/core/src/test/scala/com/qvantel/jsonapi/ToManySpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/ToManySpec.scala
@@ -284,4 +284,48 @@ final class ToManySpec extends Specification with MatcherMacros {
         "mixed reference and loaded types found")
     }
   }
+
+  "write" should {
+    "work with sparse fieldsets" in {
+
+      val article = Article("1", "boom", ToMany.loaded(Seq(Comment("2", "hello"), Comment("3", "world"))))
+
+      implicit val sparseFields: Map[String, List[String]] =
+        Map("articles" -> List("title"), "comments" -> List("fieldThatDoesNotExist"))
+
+      val rawJson =
+        """
+          |{
+          |  "data": {
+          |    "attributes": {
+          |       "title": "boom"
+          |    },
+          |    "links": {
+          |      "self": "/articles/1"
+          |    },
+          |    "id": "1",
+          |    "type": "articles"
+          |  },
+          |  "included": [
+          |    {
+          |      "id": "2",
+          |      "links": {
+          |        "self":"/comments/2"
+          |      },
+          |      "type": "comments"
+          |    },
+          |    {
+          |      "id": "3",
+          |      "links": {
+          |        "self":"/comments/3"
+          |      },
+          |      "type": "comments"
+          |    }
+          |  ]
+          |}
+        """.stripMargin.parseJson.asJsObject
+
+      rawOne(article) must be equalTo rawJson
+    }
+  }
 }

--- a/model/src/main/scala/com/qvantel/jsonapi/model/TopLevel.scala
+++ b/model/src/main/scala/com/qvantel/jsonapi/model/TopLevel.scala
@@ -169,6 +169,13 @@ object TopLevel {
   }
 
   implicit object TopLevelJsonFormat extends JsonApiFormat[TopLevel] {
+
+    override def write(obj: TopLevel, sparseFields: Map[String, List[String]]): JsValue = obj match {
+      case s: Single     => SingleJsonFormat.write(s)
+      case c: Collection => CollectionJsonFormat.write(c)
+      case e: Errors     => ErrorsJsonFormat.write(e)
+    }
+
     override def write(obj: TopLevel): JsValue = obj match {
       case s: Single     => SingleJsonFormat.write(s)
       case c: Collection => CollectionJsonFormat.write(c)
@@ -188,11 +195,12 @@ object TopLevel {
       })
     }
 
-    override def included(obj: TopLevel): Set[JsObject] = obj match {
-      case s: Single     => s.included.values.map(_.toJson.asJsObject).toSet
-      case c: Collection => c.included.values.map(_.toJson.asJsObject).toSet
-      case e: Errors     => Set.empty
-    }
+    override def included(obj: TopLevel, sparseFields: Map[String, List[String]] = Map.empty): Set[JsObject] =
+      obj match {
+        case s: Single     => s.included.values.map(_.toJson.asJsObject).toSet
+        case c: Collection => c.included.values.map(_.toJson.asJsObject).toSet
+        case e: Errors     => Set.empty
+      }
 
     override def read(primary: JsValue,
                       included: Map[(String, String), JsObject],

--- a/spray/src/test/scala/com/qvantel/jsonapi/JsonApiSortingSpec.scala
+++ b/spray/src/test/scala/com/qvantel/jsonapi/JsonApiSortingSpec.scala
@@ -57,9 +57,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
     """
       |{
       |  "data": {
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "data": [{
@@ -81,9 +78,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       |    "type": "res"
       |  },
       |  "included": [{
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -97,9 +91,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       |    "id": "3",
       |    "type": "res"
       |  }, {
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -120,9 +111,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
     """
       |{
       |  "data": [{
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -136,9 +124,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       |    "id": "1",
       |    "type": "res"
       |  }, {
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -152,9 +137,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       |    "id": "3",
       |    "type": "res"
       |  }, {
-      |    "attributes": {
-      |
-      |    },
       |    "relationships": {
       |      "rel": {
       |        "links": {
@@ -191,9 +173,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       """
         |{
         |  "data": {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "data": [{
@@ -215,9 +194,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "type": "res"
         |  },
         |  "included": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -231,9 +207,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -254,9 +227,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       """
         |{
         |  "data": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -270,9 +240,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "1",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -286,9 +253,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -322,9 +286,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       """
         |{
         |  "data": {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "data": [{
@@ -346,9 +307,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "type": "res"
         |  },
         |  "included": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -362,9 +320,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "3",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -385,9 +340,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       """
         |{
         |  "data": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -401,9 +353,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "3",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -417,9 +366,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -454,9 +400,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       """
         |{
         |  "data": {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "data": [{
@@ -478,9 +421,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "type": "res"
         |  },
         |  "included": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -494,9 +434,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -517,9 +454,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       """
         |{
         |  "data": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -533,9 +467,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "1",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -549,9 +480,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -585,9 +513,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       """
         |{
         |  "data": {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "data": [{
@@ -609,9 +534,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "type": "res"
         |  },
         |  "included": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -625,9 +547,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -648,9 +567,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
       """
         |{
         |  "data": [{
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -664,9 +580,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "1",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {
@@ -680,9 +593,6 @@ final class JsonApiSortingSpec extends Specification with Specs2RouteTest with H
         |    "id": "2",
         |    "type": "res"
         |  }, {
-        |    "attributes": {
-        |
-        |    },
         |    "relationships": {
         |      "rel": {
         |        "links": {


### PR DESCRIPTION
For more information see: https://jsonapi.org/format/#fetching-sparse-fieldsets
Breaking change is due to :
  * The removal of the "attributes", "relationships", "links" and "meta" fields if they are empty
  * Adding additional functions to the JsonApiWriter which requires definitions when implementing the trait