### PR TITLE
feat: 'mixed reference and loaded types found' error message enrichment

### DIFF
--- a/core/src/main/scala/com/qvantel/jsonapi/macrosupport/JsonApiReaders.scala
+++ b/core/src/main/scala/com/qvantel/jsonapi/macrosupport/JsonApiReaders.scala
@@ -233,7 +233,13 @@ trait JsonApiReaders extends JsonApiCommon {
               } else if (entities.forall(_.isEmpty)) {
                 _root_.com.qvantel.jsonapi.ToMany.reference[$containedType](data.map { x => x.fields.get("id").map(_.convertTo[String]).getOrElse(throw new _root_.spray.json.DeserializationException("'id' not found in " + x.compactPrint)) }.toSet)
               } else {
-                throw new _root_.spray.json.DeserializationException("mixed reference and loaded types found")
+                val missedEntities = data.zip(entities).collect {
+                  case (x, _root_.scala.None) =>
+                    val tpe = x.fields.get("type").map(_.convertTo[String]).getOrElse(throw new _root_.spray.json.DeserializationException("'type' not found in " + x.compactPrint))
+                    val id = x.fields.get("id").map(_.convertTo[String]).getOrElse(throw new _root_.spray.json.DeserializationException("'id' not found in " + x.compactPrint))
+                    tpe + ":" + id
+                }
+                throw new _root_.spray.json.DeserializationException("mixed reference and loaded types found, following are missed: [" + missedEntities.mkString(", ") + "]")
               }
             } else {
               _root_.com.qvantel.jsonapi.ToMany.reference[$containedType](data.map { x =>
@@ -314,7 +320,13 @@ trait JsonApiReaders extends JsonApiCommon {
                   (id, tpe)
                 }.toSet)
               } else {
-                throw new _root_.spray.json.DeserializationException("mixed reference and loaded types found")
+                val missedEntities = data.zip(entities).collect {
+                  case (x, _root_.scala.None) =>
+                    val tpe = x.fields.get("type").map(_.convertTo[String]).getOrElse(throw new _root_.spray.json.DeserializationException("'type' not found in " + x.compactPrint))
+                    val id = x.fields.get("id").map(_.convertTo[String]).getOrElse(throw new _root_.spray.json.DeserializationException("'id' not found in " + x.compactPrint))
+                    tpe + ":" + id
+                }
+                throw new _root_.spray.json.DeserializationException("mixed reference and loaded types found, following are missed: [" + missedEntities.mkString(", ") + "]")
               }
             } else {
               _root_.com.qvantel.jsonapi.PolyToMany.reference[$containedType](data.map { x =>

--- a/core/src/test/scala/com/qvantel/jsonapi/PolyToManySpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/PolyToManySpec.scala
@@ -241,6 +241,9 @@ final class PolyToManySpec extends Specification {
           |        }, {
           |          "type": "companies",
           |          "id": "evil"
+          |        }, {
+          |          "type": "companies",
+          |          "id": "good"
           |        }],
           |        "links": {
           |          "related": "/articles/1/authors"
@@ -266,7 +269,7 @@ final class PolyToManySpec extends Specification {
           |}
         """.stripMargin.parseJson.asJsObject
       readOne[Article](json, Set("authors")) must throwA[DeserializationException](
-        "mixed reference and loaded types found")
+        "mixed reference and loaded types found, following are missed: \\[companies:evil, companies:good\\]")
     }
   }
 

--- a/core/src/test/scala/com/qvantel/jsonapi/ToManySpec.scala
+++ b/core/src/test/scala/com/qvantel/jsonapi/ToManySpec.scala
@@ -257,6 +257,9 @@ final class ToManySpec extends Specification with MatcherMacros {
           |        }, {
           |          "type": "comments",
           |          "id": "3"
+          |        }, {
+          |          "type": "comments",
+          |          "id": "4"
           |        }],
           |        "links": {
           |          "related": "/articles/1/comments"
@@ -282,7 +285,7 @@ final class ToManySpec extends Specification with MatcherMacros {
           |}
         """.stripMargin.parseJson.asJsObject
       readOne[Article](json, Set("comments")) must throwA[DeserializationException](
-        "mixed reference and loaded types found")
+        "mixed reference and loaded types found, following are missed: \\[comments:3, comments:4\\]")
     }
   }
 


### PR DESCRIPTION
'mixed reference and loaded types found' error messages are too vague, let's log missed entities from includes as well
e.g. before:
`mixed reference and loaded types found`
Note: it doesn't give you a clue what exactly went wrong with your JSON file.

now:
`mixed reference and loaded types found, following are missed: [companies:evil, companies:good]`